### PR TITLE
fix: Now only adds owners once

### DIFF
--- a/apps/website/src/lib/server/actions/households.actions.ts
+++ b/apps/website/src/lib/server/actions/households.actions.ts
@@ -22,30 +22,15 @@ export async function addHousehold(household: HouseholdInsertArgs) {
       .insert(schema.households)
       .values(household)
       .returning();
+
     if (!newHome) {
       tx.rollback();
       return null;
     }
 
-    const [newUserToHousehold] = await tx
-      .insert(schema.usersToHouseholds)
-      .values({
-        householdId: newHome.id,
-        userId: household.ownerId,
-      })
-      .returning();
-
-    if (newUserToHousehold) {
-      return newHome;
-    }
-
-    return null;
+    return newHome;
   });
 }
-
-// export async function updateHousehold(householdId: string, data: Partial<Omit<Household, 'id'>>) {
-//   return {};
-// }
 
 export async function deleteHousehold(householdId: string) {
   const household = await db.query.households.findFirst({

--- a/apps/website/src/routes/dashboard/household/+page.server.ts
+++ b/apps/website/src/routes/dashboard/household/+page.server.ts
@@ -85,7 +85,7 @@ export const actions = {
   },
   addHousehold: async ({ request, locals }) => {
     const session = await locals.getSession();
-    if (!validateUserSession(session)) error(400);
+    if (!validateUserSession(session)) throw error(400);
 
     const data = formDataValidObject(
       await request.formData(),
@@ -106,7 +106,7 @@ export const actions = {
       ownerId: session.user.id,
     });
 
-    if (household === null) error(400);
+    if (household === null) throw error(400);
 
     const responses = await inviteMembersByEmail(
       locals.supabase,


### PR DESCRIPTION
In production I had a trigger running to automatically create a map from a new household row to the `users_to_households` table.

In dev I had forgotten to copy over that trigger, and so in dev I needed code in order to add the user.