### PR TITLE
tests: Add in more thorough tests for Households

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,63 @@
+name: Playwright Tests
+
+on:
+  deployment_status:
+jobs:
+  run-e2es:
+    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache/restore@v4
+        name: Setup PNPM cache
+        id: npm-cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-
+      - uses: pnpm/action-setup@v4
+        name: Install PNPM
+        with:
+          version: 9.0.5
+
+      - uses: actions/cache/restore@v4
+        name: Restore Playwright from Cache
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+            ${{ runner.os }}-playwright-store-
+            ${{ runner.os }}-playwright-
+
+      - name: Install packages
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: pnpm i --frozen-lockfile
+      - uses: actions/cache/save@v4
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ steps.npm-cache.outputs.cache-primary-key }}
+
+      - name: Install Playwright
+        run: cd apps/website && pnpx playwright install --with-deps && pnpm exec playwright install chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+
+      - name: Run tests
+        id: e2e
+        run: cd apps/website && pnpm test:e2e
+        env:
+          BASE_URL: ${{ github.event.deployment_status.environment_url }}
+          TEST_USER: ${{ secrets.TEST_USER }}
+          TEST_PW: ${{ secrets.TEST_PW }}
+          TEST_SECRET: ${{ secrets.TEST_SECRET }}
+      - name: Upload test artifacts
+        if: ${{ failure() && steps.e2e.conclusion == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: apps/website/test-results

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install PNPM
         with:
           version: 9.0.5
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install PNPM
         with:
           version: 9.0.5

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -12,7 +12,7 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "eslint .",
-    "test:integration": "playwright test",
+    "test:e2e": "playwright test",
     "test:unit": "vitest",
     "story:dev": "histoire dev"
   },

--- a/apps/website/playwright.config.ts
+++ b/apps/website/playwright.config.ts
@@ -1,12 +1,19 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
+import 'dotenv/config';
 
 const config: PlaywrightTestConfig = {
-  webServer: {
-    command: 'npm run build && npm run preview',
-    port: 4173,
-  },
+  webServer: !process.env.CI
+    ? {
+        command: 'npm run preview',
+        baseURL: process.env.BASE_URL || 'http://localhost:4173',
+      }
+    : undefined,
   testDir: 'tests',
   testMatch: /(.+\.)?(test|spec)\.[jt]s/,
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:4173',
+    trace: 'retain-on-failure',
+  },
 };
 
 export default config;

--- a/apps/website/src/routes/dashboard/household/_components/householdSidebar.svelte
+++ b/apps/website/src/routes/dashboard/household/_components/householdSidebar.svelte
@@ -32,7 +32,10 @@
   </Drawer>
 {/if}
 
-<section class="bg-surface-50-900-token p-4 overflow-auto min-w-max">
+<section
+  data-testid="sidebar-household"
+  class="bg-surface-50-900-token p-4 overflow-auto min-w-max"
+>
   <div class="flex flex-col gap-2">
     <header class="flex justify-between gap-4 mb-4">
       <h3 class="h3">Households</h3>

--- a/apps/website/tests/dashboard.test.ts
+++ b/apps/website/tests/dashboard.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test';
+import { navigateAndLoginTo } from './util';
+
+test('Dashboard redirects to login page when user is not logged in', async ({
+  page,
+}) => {
+  await navigateAndLoginTo('/dashboard', page);
+  await expect(
+    page.getByRole('heading', { name: `${process.env.TEST_USER} Dashboard` }),
+  ).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Past Due' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Upcoming' })).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Coming Soon' }),
+  ).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Paid' })).toBeVisible();
+});

--- a/apps/website/tests/homepage.test.ts
+++ b/apps/website/tests/homepage.test.ts
@@ -1,0 +1,40 @@
+import { expect, test, type Page } from '@playwright/test';
+import { login } from './util';
+
+async function checkBasics(page: Page) {
+  await expect(
+    page.getByRole('heading', { name: 'Sungmanito', exact: true }),
+  ).toBeVisible();
+  await expect(
+    // eslint-disable-next-line quotes
+    page.getByText("Don't just track your bills, hunt them.", { exact: false }),
+  ).toBeInViewport();
+}
+
+test('Index has the proper text', async ({ page }) => {
+  await page.goto('/');
+  await checkBasics(page);
+});
+
+test('Listens to users color preferences', async ({ page }) => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await page.goto('/');
+  await checkBasics(page);
+  // DOWNSTREAM: add in accessibility checks to ensure main texts are readible in light/dark mode
+});
+
+test('Dark mode switches correctly', async ({ page }) => {
+  await page.goto('/');
+  await page.getByLabel('Light Switch').click();
+  await checkBasics(page);
+});
+
+test('Login', async ({ page }) => {
+  await page.goto('/');
+  await page.getByText('Login').click();
+  await login(page);
+  await page.waitForURL(/dashboard/);
+  await expect(
+    page.getByText(`${process.env.TEST_USER} Dashboard`),
+  ).toBeInViewport();
+});

--- a/apps/website/tests/households.test.ts
+++ b/apps/website/tests/households.test.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+
+import { login } from './util';
+
+test('Navigating and logging in redirection works', async ({ page }) => {
+  await page.goto('/');
+  await page.goto('/dashboard/household');
+  await login(page);
+  await expect(
+    page.getByRole('heading', { name: 'Households', level: 1 }),
+  ).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Invites' })).toBeVisible();
+  await expect(page.getByTestId('sidebar-household')).toBeVisible();
+  expect(page.url()).toMatch('/dashboard/household');
+});
+
+test('User can create household through dialog', async ({ page }) => {
+  await page.goto('/');
+  await page.goto('/dashboard/household');
+  await login(page);
+  await page
+    .locator('section')
+    .filter({ hasText: /^Add$/ })
+    .getByRole('button')
+    .click();
+  await expect(page.getByText('New household')).toBeVisible();
+  await page.getByLabel('Household Name').fill('Household 1');
+  await page.getByRole('dialog').getByRole('button', { name: 'Add' }).click();
+  await expect(page.getByRole('dialog')).not.toBeVisible();
+  await expect(
+    page.getByTestId('sidebar-household').getByText('Household 1'),
+  ).toBeVisible();
+});
+
+test('User can view household details', async ({ page }) => {
+  await page.goto('/');
+  await page.goto('/dashboard/household');
+  await login(page);
+
+  await page.getByTestId('sidebar-household').getByText('Household 1').click();
+  await expect(
+    page.getByRole('heading', { name: 'Household 1' }),
+  ).toBeInViewport();
+});
+
+test('User can edit', async ({ page }) => {
+  await page.goto('/');
+  await page.goto('/dashboard/household');
+  await login(page);
+
+  await page.getByTestId('sidebar-household').getByText('Household 1').click();
+
+  await page.getByRole('button', { name: 'Edit' }).click();
+  await page.getByLabel('Household Name').clear();
+  await page.getByLabel('Household Name').fill('Edited Household 1');
+  await page.getByRole('dialog').getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByTestId('sidebar-household').getByText('Edited Household 1'),
+  ).toBeVisible();
+});
+
+test('User can delete household', async ({ page }) => {
+  await page.goto('/');
+  await page.goto('/dashboard/household');
+  await login(page);
+
+  await page
+    .getByTestId('sidebar-household')
+    .getByText('Edited Household 1')
+    .click();
+  await page.getByRole('button', { name: 'Delete' }).click();
+  await page.getByRole('dialog').getByRole('textbox').fill('delete');
+  await page
+    .getByRole('dialog')
+    .getByRole('button', { name: 'Delete' })
+    .click();
+  await expect(
+    page.getByTestId('sidebar-household').getByText('Edited Household 1'),
+  ).not.toBeVisible();
+});

--- a/apps/website/tests/test.ts
+++ b/apps/website/tests/test.ts
@@ -1,8 +1,0 @@
-import { expect, test } from '@playwright/test';
-
-test('index page has expected h1', async ({ page }) => {
-  await page.goto('/');
-  await expect(
-    page.getByRole('heading', { name: 'Welcome to SvelteKit' }),
-  ).toBeVisible();
-});

--- a/apps/website/tests/util.ts
+++ b/apps/website/tests/util.ts
@@ -1,0 +1,47 @@
+import type { Page } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
+
+export async function login(page: Page) {
+  await page.getByLabel('Username').fill(process.env.TEST_USER || '');
+  await page.getByLabel('Password').fill(process.env.TEST_PW || '');
+  await page.getByText('Submit').click();
+}
+
+export async function navigateAndLoginTo(url: string, page: Page) {
+  await page.goto('/');
+  await page.goto(url);
+  await login(page);
+}
+
+// Content shamelessly stolen from https://github.com/microsoft/playwright/issues/10667#issuecomment-998397241
+export async function dragAndDropFile(
+  page: Page,
+  selector: string,
+  filePath: string,
+  fileType: string,
+) {
+  const buffer = await readFile(filePath).then((b) => b.toString('base64'));
+
+  // Create the DataTransfer and File
+  const dataTransfer = await page.evaluateHandle(
+    async (data) => {
+      const dt = new DataTransfer();
+      // Convert the buffer to a hex array
+      const blob = await fetch(data.buffer).then((r) => r.blob());
+      const file = new File([blob], data.fileName, {
+        type: data.fileType,
+      });
+      dt.items.add(file);
+      return dt;
+    },
+    {
+      buffer: `data:application/octet-stream;base64,${buffer}`,
+      fileName: basename(filePath),
+      fileType,
+    },
+  );
+
+  // Now dispatch
+  await page.dispatchEvent(selector, 'drop', { dataTransfer });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1282,6 +1282,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.12.1:
+    resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -2416,12 +2421,11 @@ packages:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
     engines: {node: '>=12'}
 
+  magic-string@0.30.10:
+    resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
+
   magic-string@0.30.5:
     resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
-    engines: {node: '>=12'}
-
-  magic-string@0.30.8:
-    resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
     engines: {node: '>=12'}
 
   magicast@0.2.8:
@@ -4761,6 +4765,8 @@ snapshots:
 
   acorn@8.11.3: {}
 
+  acorn@8.12.1: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.3.4
@@ -6056,11 +6062,11 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  magic-string@0.30.5:
+  magic-string@0.30.10:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  magic-string@0.30.8:
+  magic-string@0.30.5:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
@@ -6890,7 +6896,7 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.25
       '@types/estree': 1.0.5
-      acorn: 8.11.3
+      acorn: 8.12.1
       aria-query: 5.3.0
       axobject-query: 4.0.0
       code-red: 1.0.4
@@ -6898,7 +6904,7 @@ snapshots:
       estree-walker: 3.0.3
       is-reference: 3.0.2
       locate-character: 3.0.0
-      magic-string: 0.30.8
+      magic-string: 0.30.10
       periscopic: 3.1.0
 
   svelte@4.2.8:


### PR DESCRIPTION
- Created a new GitHub Action workflow (`e2e.yml`) for running Playwright tests on deployment success.
- Modified existing GitHub Action workflows to update `PNPM` action to version 4.
- Updated `package.json` scripts: Renamed `test:integration` to `test:e2e`.
- Updated Playwright configuration to conditionally run the webserver based on the `CI` environment variable.
- Added new Playwright tests for the dashboard, homepage, and household functionalities.
- Added utility functions for logging in and common test operations.

---

tests related to the creation, viewing, editing, and deletion of households. Includes navigation to different household-related pages and form interactions.

---

