### PR TITLE
feat(household): Adds ability to create a bill from the household page

### DIFF
--- a/apps/website/src/routes/dashboard/household/[id=ulid]/+page.svelte
+++ b/apps/website/src/routes/dashboard/household/[id=ulid]/+page.svelte
@@ -10,6 +10,7 @@
   import DeleteHousehold from '$lib/components/households/delete.svelte';
   import BillDetails from '../../bills/[id=ulid]/+page.svelte';
   import EditHousehold from './edit/+page.svelte';
+  import CreateBillPage from '../../bills/create/+page.svelte';
 
   export let data;
 
@@ -20,6 +21,8 @@
 
   let editBillUrl = '';
   let showEditHousehold = false;
+  let showCreateBill = false;
+  let showCreateBillUrl = '';
 
   $: household = data.household;
   if (household === undefined) {
@@ -52,6 +55,12 @@
   }}
   component={BillDetails}
   url={billDetailUrl}
+/>
+
+<Drawerify
+  bind:open={showCreateBill}
+  url={showCreateBillUrl}
+  component={CreateBillPage}
 />
 
 <Drawerify
@@ -110,6 +119,19 @@
   </header>
   <div class="flex gap-4">
     <main class="flex-grow">
+      <Header tag="h3">
+        <svelte:fragment slot="actions">
+          <Button
+            size="sm"
+            variant="secondary"
+            on:click={() => {
+              showCreateBillUrl = `/dashboard/bills/create?household-id[]=${household.id}`;
+              showCreateBill = true;
+            }}>Add</Button
+          >
+        </svelte:fragment>
+        Bills
+      </Header>
       {#await data.streamed.bills}
         <div class="placeholder animate-pulse" />
       {:then bills}


### PR DESCRIPTION
### TL;DR

Adds functionality to create a new bill directly from the household dashboard using a drawer component.

### What changed?

- Imported the `CreateBillPage` and `Drawer` components.
- Added a new button to open the create bill drawer.
- Implemented the necessary state variables and event handlers for the drawer.

### How to test?

1. Navigate to the household dashboard.
2. Click the 'Add' button in the Bills section.
3. Verify that the create bill drawer opens.
4. Fill out the form and submit to create a new bill.

### Why make this change?

To allow users to easily add new bills directly from the household dashboard, enhancing the user experience by reducing navigation steps.

---

Resolves #49