### PR TITLE
chore: Add Drawer stories

### DIFF
--- a/apps/website/src/lib/components/drawer/drawer.stories.svelte
+++ b/apps/website/src/lib/components/drawer/drawer.stories.svelte
@@ -1,0 +1,19 @@
+<script lang="ts" module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import Drawer from './drawer.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Drawer',
+    component: Drawer,
+    tags: ['autodocs'],
+    args: {
+      open: true,
+    },
+  });
+</script>
+
+{#snippet children()}
+  <div class="p-4">I am the content</div>
+{/snippet}
+
+<Story name="Default" args={{ children }} />


### PR DESCRIPTION
### TL;DR

Added Storybook story for the Drawer component.

### What changed?

Created a new Storybook story file for the Drawer component that demonstrates its basic usage with a simple content example. The story is configured with autodocs enabled and shows the drawer in an open state by default.

### How to test?

1. Run Storybook locally
2. Navigate to the Drawer component in the sidebar
3. Verify that the drawer appears with "I am the content" displayed
4. Check that the component documentation is automatically generated

### Why make this change?

To provide interactive documentation for the Drawer component, making it easier for developers to understand its usage and behavior. This also ensures consistent documentation practices across components in the design system.