### PR TITLE
chore: cleaning up table definitions

### DIFF
--- a/apps/website/src/lib/components/payments/details.svelte
+++ b/apps/website/src/lib/components/payments/details.svelte
@@ -1,6 +1,0 @@
-<script lang="ts">
-  import type { PageServerData } from '../../../routes/dashboard/payments/[id=ulid]/$types';
-  export let payment: PageServerData['payment'];
-</script>
-
-... thinking...

--- a/apps/website/src/routes/dashboard/+page.server.ts
+++ b/apps/website/src/routes/dashboard/+page.server.ts
@@ -37,7 +37,10 @@ export const load = async ({ locals, depends }) => {
     .leftJoin(
       exportedSchema.payments,
       and(
-        eq(exportedSchema.payments.forMonth, today.getMonth() + 1),
+        eq(
+          sql`extract('month' from ${exportedSchema.payments.forMonthD})`,
+          today.getMonth() + 1,
+        ),
         eq(exportedSchema.payments.billId, exportedSchema.bills.id),
       ),
     );
@@ -152,7 +155,6 @@ export const actions = {
             bill.dueDate,
           ),
           householdId: bill.householdId,
-          forMonth: today.getMonth() + 1,
         });
       }
 

--- a/apps/website/src/routes/dashboard/payments/+page.server.ts
+++ b/apps/website/src/routes/dashboard/payments/+page.server.ts
@@ -15,7 +15,7 @@ import { validateUserSession } from '$lib/util/session.js';
 import { exportedSchema as schema } from '@sungmanito/db';
 import { error, fail, redirect } from '@sveltejs/kit';
 import { instanceOf, type } from 'arktype';
-import { and, eq, getTableColumns, inArray } from 'drizzle-orm';
+import { and, eq, getTableColumns, inArray, sql } from 'drizzle-orm';
 
 export const load = async ({ locals, depends }) => {
   const today = new Date();
@@ -49,8 +49,13 @@ export const load = async ({ locals, depends }) => {
       schema.households,
       eq(schema.households.id, schema.payments.householdId),
     )
-    .where(eq(schema.payments.forMonth, today.getMonth() + 1))
-    .orderBy(schema.payments.forMonth);
+    .where(
+      eq(
+        sql`extract('month' from ${schema.payments.forMonthD})`,
+        today.getMonth() + 1,
+      ),
+    )
+    .orderBy(schema.payments.forMonthD);
 
   return {
     payments,

--- a/apps/website/src/routes/login/+page.svelte
+++ b/apps/website/src/routes/login/+page.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import { enhance } from '$app/forms';
   import { goto, invalidateAll } from '$app/navigation';
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import { getToastStore } from '@skeletonlabs/skeleton';
 
-  export let data;
   const toastStore = getToastStore();
 
   let email = '';
@@ -22,7 +21,7 @@
     return async ({ result }) => {
       if (result.type === 'success') {
         await invalidateAll();
-        await goto($page.url.searchParams.get('url') || '/dashboard');
+        await goto(page.url.searchParams.get('url') || '/dashboard');
       } else if (result.type === 'error') {
         toastStore.trigger({
           message: 'Error occurred',

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -2,11 +2,11 @@ import type { Config } from 'drizzle-kit';
 import 'dotenv/config';
 
 export default {
+  dialect: 'postgresql',
   schema: './src/tables/index.ts',
   out: './drizzle',
-  driver: 'pg',
   schemaFilter: ['public'],
   dbCredentials: {
-    connectionString: process.env.DB_URL!,
+    url: process.env.DB_URL!,
   },
 } satisfies Config;

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,8 +3,8 @@
   "main": "./src/index.ts",
   "version": "0.1.0",
   "scripts": {
-    "db:push": "drizzle-kit push:pg",
-    "db:generate": "drizzle-kit generate:pg",
+    "db:push": "drizzle-kit push",
+    "db:generate": "drizzle-kit generate",
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {

--- a/packages/db/src/tables/bills.table.ts
+++ b/packages/db/src/tables/bills.table.ts
@@ -5,7 +5,6 @@ import { sql } from 'drizzle-orm';
 export const bills = pgTable(
   'bills',
   {
-    // Think we're going to use ULID here.
     id: text('id')
       .primaryKey()
       .default(sql`generate_ulid()`),

--- a/packages/db/src/tables/households.table.ts
+++ b/packages/db/src/tables/households.table.ts
@@ -15,7 +15,8 @@ export const households = pgTable(
       .references(() => users.id),
   },
   // Creating an index on the name as we will search on it.
-  ({ name }) => ({
+  ({ name, ownerId }) => ({
     name: index('name_index').on(name),
+    ownerId: index('owner_id').on(ownerId),
   }),
 );

--- a/packages/db/src/tables/index.ts
+++ b/packages/db/src/tables/index.ts
@@ -10,7 +10,3 @@ export * from './usersToHouseholds.table';
 export * from './invites.table';
 export * from './objects.table';
 export * from './buckets.table';
-
-export const testingTable = pgTable('pgTable', {
-  id: uuid('id').notNull().primaryKey().defaultRandom(),
-});

--- a/packages/db/src/tables/invites.table.ts
+++ b/packages/db/src/tables/invites.table.ts
@@ -21,8 +21,9 @@ export const invites = pgTable(
       .notNull()
       .default(sql<string>`now() + interval '30 days'`),
   },
-  ({ toId, fromId }) => ({
+  ({ toId, fromId, householdId }) => ({
     toIdIdx: index('to_id_idx').on(toId),
     fromIdx: index('from_id_idx').on(fromId),
+    householdId: index('invites_household_idx').on(householdId),
   }),
 );

--- a/packages/db/src/tables/objects.table.ts
+++ b/packages/db/src/tables/objects.table.ts
@@ -2,8 +2,6 @@ import { uuid, text } from 'drizzle-orm/pg-core';
 import { buckets, storageSchema } from './buckets.table';
 import { users } from '.';
 
-// export const storageSchema = pgSchema('storage');
-
 export const objects = storageSchema.table('objects', {
   id: uuid('id').notNull().defaultRandom(),
   bucketId: text('bucket_id')

--- a/packages/db/src/tables/payments.table.ts
+++ b/packages/db/src/tables/payments.table.ts
@@ -29,8 +29,6 @@ export const payments = pgTable(
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),
-    // TODO: Remove this
-    forMonth: smallint('for_month').notNull().default(1),
     forMonthD: date('for_month_d', { mode: 'date' }).notNull(),
     notes: text('notes'),
     proofImage: uuid('proof_image_id').references(() => objects.id, {
@@ -42,8 +40,8 @@ export const payments = pgTable(
       .notNull()
       .references(() => households.id, { onDelete: 'no action' }),
   },
-  ({ billId, forMonth, forMonthD, proofImage, householdId }) => ({
-    billIdMonth: uniqueIndex('billId_month').on(billId, forMonth),
+  ({ billId, forMonthD, proofImage, householdId }) => ({
+    billIdMonth: uniqueIndex('billId_month').on(billId, forMonthD),
     monthIndex: index('month_idx').on(forMonthD),
     proofImageIndex: uniqueIndex('proof_image_idx').on(proofImage),
     householdIndex: index('payment_household_idx').on(householdId),

--- a/packages/db/src/tables/usersToHouseholds.table.ts
+++ b/packages/db/src/tables/usersToHouseholds.table.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, uuid, index } from 'drizzle-orm/pg-core';
+import { pgTable, text, uuid, index, uniqueIndex } from 'drizzle-orm/pg-core';
 import { users } from './users.table';
 import { households } from './households.table';
 
@@ -13,7 +13,12 @@ export const usersToHouseholds = pgTable(
       .notNull()
       .references(() => households.id, { onDelete: 'cascade' }),
   },
-  ({ userId }) => ({
+  ({ userId, householdId }) => ({
     userIdIndex: index('household_user_id_index').on(userId),
+    householdIdx: index('household_household_id_index').on(householdId),
+    userHouseholdIdx: uniqueIndex('user_id_household_id_index').on(
+      userId,
+      householdId,
+    ),
   }),
 );


### PR DESCRIPTION
### TL;DR
Removed the numeric `forMonth` column from payments table and updated queries to use date extraction from `forMonthD`. Added new database indexes for performance optimization.

### What changed?
- Removed deprecated `forMonth` column from payments table
- Updated SQL queries to use `extract('month' from forMonthD)` instead of numeric month
- Added new indexes on `households` and `usersToHouseholds` tables
- Removed unused test table
- Updated drizzle configuration to use newer syntax
- Added unique constraint on user-household relationships

### How to test?
1. Run database migrations
2. Verify bill payments still display correctly on dashboard
3. Verify new payments can be created
4. Verify household member management still functions
5. Check that duplicate user-household relationships cannot be created

### Why make this change?
The numeric `forMonth` column was redundant since we already store the full date in `forMonthD`. Using date extraction provides more accurate month handling and reduces data duplication. The additional indexes will improve query performance for household and user relationship lookups.
