### PR TITLE
test: Add in dropzone stories

### DIFF
--- a/apps/website/.storybook/main.ts
+++ b/apps/website/.storybook/main.ts
@@ -2,6 +2,7 @@ import type { StorybookConfig } from '@storybook/sveltekit';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|ts|svelte)'],
+  staticDirs: ['../static'],
   addons: [
     '@storybook/addon-svelte-csf',
     '@storybook/addon-essentials',

--- a/apps/website/src/lib/components/dropzone/dropzone.stories.svelte
+++ b/apps/website/src/lib/components/dropzone/dropzone.stories.svelte
@@ -7,6 +7,14 @@
     component: Dropzone,
     tags: ['autodocs'],
   });
+
+  function ondragstart(e: DragEvent) {
+    if (e.target && e.target instanceof HTMLElement) {
+      e.dataTransfer?.setData('text', e.target.dataset['color'] || '');
+    }
+  }
+
+  let color: string = $state('');
 </script>
 
 {#snippet defaultChildren()}
@@ -20,3 +28,49 @@
 <Story name="Default" args={{ children: defaultChildren }} />
 
 <Story name="With Dragover" args={{ children: defaultChildren, dragover }} />
+
+<Story name="Kitchen Sink">
+  {#snippet children()}
+    <div class="flex gap-4" data-testid="color-header">
+      <div
+        class="draggable"
+        draggable="true"
+        role="note"
+        data-color="#fef03f"
+        {ondragstart}
+      >
+        Yellow Color
+      </div>
+      <div
+        class="draggable"
+        data-color="#ee1009"
+        {ondragstart}
+        draggable="true"
+        role="note"
+      >
+        Red color
+      </div>
+    </div>
+
+    <Dropzone
+      ondrop={(e, i) => {
+        console.info(e, i);
+        const id = e.dataTransfer?.getData('text');
+        if (id) color = id;
+      }}
+    >
+      {#snippet dragover()}
+        <div class="text-token">I am shown on dragover</div>
+      {/snippet}
+      <div class="flex border border-blue-400 p-3">
+        {#if color !== ''}
+          <div class="h-10 w-10" style={`background-color: ${color}`}>
+            {color}
+          </div>
+        {:else}
+          Drag and drop elements here
+        {/if}
+      </div>
+    </Dropzone>
+  {/snippet}
+</Story>


### PR DESCRIPTION
### TL;DR
Added drag and drop functionality to the Dropzone component's Storybook stories.

### What changed?
- Added static directory configuration to Storybook
- Created a new "Kitchen Sink" story demonstrating drag and drop functionality
- Implemented color-based drag and drop example with yellow and red draggable elements
- Added state management for tracking dropped colors
- Included drag event handlers and visual feedback

### How to test?
1. Navigate to the Dropzone component in Storybook
2. Open the "Kitchen Sink" story
3. Try dragging either the yellow or red color element
4. Drop it into the dropzone area
5. Verify that the dropped color appears in the target area
6. Confirm that dragover states display correctly

### Why make this change?
To provide a comprehensive example of the Dropzone component's drag and drop capabilities, making it easier for developers to understand and implement the component in their applications.