### PR TITLE
feat: Add in Alert component,No tests as it's almost entirely a display-based component

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,7 +9,7 @@ reviews:
   high_level_summary_placeholder: '@coderabbitai summary'
   auto_title_placeholder: '@coderabbitai'
   auto_title_instructions: ''
-  review_status: true
+  review_status: false 
   commit_status: true
   collapse_walkthrough: false
   changed_files_summary: true

--- a/apps/website/.storybook/main.ts
+++ b/apps/website/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/sveltekit';
 
 const config: StorybookConfig = {
-  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|ts|svelte)'],
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|ts|svelte|md)'],
   staticDirs: ['../static'],
   addons: [
     '@storybook/addon-svelte-csf',
@@ -13,4 +13,5 @@ const config: StorybookConfig = {
     options: {},
   },
 };
+
 export default config;

--- a/apps/website/src/lib/components/alert/alert.stories.svelte
+++ b/apps/website/src/lib/components/alert/alert.stories.svelte
@@ -1,0 +1,28 @@
+<script lang="ts" module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import { AlertTriangleIcon, XIcon } from 'lucide-svelte';
+  import Alert from './alert.svelte';
+  const { Story } = defineMeta({
+    title: 'Alerts',
+    component: Alert,
+    tags: ['autodocs'],
+    args: {
+      type: 'default',
+    },
+  });
+</script>
+
+<Story name="Default">
+  {#snippet children(args)}
+    <Alert {...args}>
+      <div class="flex items-center gap-6">
+        <AlertTriangleIcon size="2em" /> Alert without thingamajig
+      </div>
+      {#snippet actions()}
+        <button class="hover:rounded-full hover:bg-secondary-hover-token p-2">
+          <XIcon size="1.5em" />
+        </button>
+      {/snippet}
+    </Alert>
+  {/snippet}
+</Story>

--- a/apps/website/src/lib/components/alert/alert.svelte
+++ b/apps/website/src/lib/components/alert/alert.svelte
@@ -1,0 +1,55 @@
+<script lang="ts" module>
+  import { cva, type VariantProps } from 'class-variance-authority';
+  import { type Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  const variants = cva('alert', {
+    variants: {
+      type: {
+        primary: 'variant-filled-primary',
+        error: 'variant-filled-error',
+        default: 'variant-filled',
+        surface: 'variant-filled-surface',
+        warning: 'variant-filled-warning',
+        success: 'variant-filled-success',
+        'primary:ghost': 'variant-ghost-primary',
+        'error:ghost': 'variant-ghost-error',
+        'surface:ghost': 'variant-ghost-surface',
+        'warning:ghost': 'variant-ghost-warning',
+        'success:ghost': 'variant-ghost-success',
+      },
+    },
+    defaultVariants: {
+      type: 'default',
+    },
+  });
+
+  export type VariantTypes = VariantProps<typeof variants>;
+
+  export interface AlertProps extends HTMLAttributes<HTMLElement> {
+    children: Snippet<[]>;
+    actions?: Snippet<[]>;
+  }
+</script>
+
+<script lang="ts">
+  let {
+    children,
+    actions,
+    type = 'default',
+    class: className,
+    ...rest
+  }: AlertProps & VariantTypes = $props();
+  let classes = $derived(variants({ type }));
+</script>
+
+<div class={classes} {...rest}>
+  <div class="alert-message">
+    {@render children()}
+  </div>
+  {#if actions}
+    <div class="alert-actions">
+      {@render actions()}
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
### TL;DR
Added a new Alert component with Storybook integration and variant support.

### What changed?
- Created a new Alert component with support for multiple variants (primary, error, warning, success, etc.)
- Added Storybook configuration to support `.md` files
- Implemented a default Alert story showcasing the component with an example using AlertTriangle and X icons
- Added type definitions and class variance authority (CVA) for styling variants

### How to test?
1. Run Storybook locally
2. Navigate to the Alerts section
3. Verify the default Alert renders correctly with icons
4. Test different variant types by modifying the story args
5. Confirm hover effects on the close button
6. Verify both filled and ghost variants work as expected

### Why make this change?
To provide a standardized alert component that can be used across the application for consistent user notifications and feedback. The component's flexible design allows for different styling variants and custom actions, making it versatile for various use cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new Alert component with customizable variants and styling
  - Expanded Storybook configuration to support additional story file types

- **Configuration**
  - Updated CodeRabbit review status settings

- **Documentation**
  - Added Storybook stories for the Alert component to demonstrate its functionality and variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->