### PR TITLE
feat(Households): Adds in a quick-and-dirty workflow for ownerless households

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,7 +9,7 @@ reviews:
   high_level_summary_placeholder: '@coderabbitai summary'
   auto_title_placeholder: '@coderabbitai'
   auto_title_instructions: ''
-  review_status: false 
+  review_status: false
   commit_status: true
   collapse_walkthrough: false
   changed_files_summary: true

--- a/apps/website/src/lib/components/alert/alert.svelte
+++ b/apps/website/src/lib/components/alert/alert.svelte
@@ -37,6 +37,7 @@
     children,
     actions,
     type = 'default',
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class: className,
     ...rest
   }: AlertProps & VariantTypes = $props();

--- a/apps/website/src/routes/dashboard/household/+page.svelte
+++ b/apps/website/src/routes/dashboard/household/+page.svelte
@@ -7,8 +7,8 @@
   import Drawerify from '$components/drawerify/drawerify.svelte';
   import { CheckIcon, XIcon } from 'lucide-svelte';
   import { pushState } from '$app/navigation';
-  export let data;
-  let showCreateHousehold = false;
+  let { data } = $props();
+  let showCreateHousehold = $state(false);
   const createHouseholdUrl = '/dashboard/household/create';
 </script>
 

--- a/apps/website/src/routes/dashboard/household/[id=ulid]/+page.svelte
+++ b/apps/website/src/routes/dashboard/household/[id=ulid]/+page.svelte
@@ -2,7 +2,13 @@
   import { enhance } from '$app/forms';
   import { goto, pushState, invalidate } from '$app/navigation';
   import Breadcrumb from '$lib/components/breadcrumb/breadcrumb.svelte';
-  import { CrownIcon, Loader2, Trash2Icon, XIcon } from 'lucide-svelte';
+  import {
+    AlertTriangleIcon,
+    CrownIcon,
+    Loader2,
+    Trash2Icon,
+    XIcon,
+  } from 'lucide-svelte';
 
   import Drawerify from '$components/drawerify/drawerify.svelte';
   import Header from '$components/header/header.svelte';
@@ -13,33 +19,35 @@
   import CreateBillPage from '../../bills/create/+page.svelte';
   import DeleteBillPage from '../../bills/[id=ulid]/delete/+page.svelte';
   import Modalify from '$components/modalify/modalify.svelte';
+  import Alert from '$components/alert/alert.svelte';
 
-  export let data;
+  let { data } = $props();
 
-  let household = data.household;
+  let household = $derived(data.household);
 
-  let billDetailUrl = '';
-  let showBillDetails = false;
+  let billDetailUrl = $state('');
+  let showBillDetails = $state(false);
 
-  let editBillUrl = '';
-  let showEditHousehold = false;
-  let showCreateBill = false;
-  let showCreateBillUrl = '';
+  let editBillUrl = $state('');
+  let showEditHousehold = $state(false);
+  let showCreateBill = $state(false);
+  let showCreateBillUrl = $state('');
 
-  $: household = data.household;
-  if (household === undefined) {
-    goto('/dashboard/household');
-  }
+  $effect(() => {
+    if (household === undefined) {
+      goto('/dashboard/household');
+    }
+  });
 
   function showEdit(householdId: string) {
     showEditHousehold = true;
     editBillUrl = `/dashboard/household/${householdId}/edit`;
   }
 
-  let showDeleteBill = false;
-  let deleteBillId = '';
+  let showDeleteBill = $state(false);
+  let deleteBillId = $state('');
 
-  let showDelete = false;
+  let showDelete = $state(false);
 </script>
 
 <svelte:head>
@@ -128,6 +136,28 @@
     ]}
   />
 
+  {#if household.ownerId === null}
+    <Alert type="warning:ghost">
+      <div class="flex items-center gap-4">
+        <AlertTriangleIcon size="2em" />
+        <div class="flex flex-col">
+          <Header tag="h3">Ownerless Household</Header>
+          <p>
+            You are viewing a household whose original owner has been removed,
+            either at their request or by administrators. Households who do not
+            have owners will be removed periodically. Please use the action to
+            the side in order to take ownership of this household.
+          </p>
+        </div>
+      </div>
+      {#snippet actions()}
+        <form action="?/claimHousehold" method="post" use:enhance>
+          <Button type="submit" variant="filled">Claim household</Button>
+        </form>
+      {/snippet}
+    </Alert>
+  {/if}
+
   <header class="flex justify-between gap-4 items-center mb-4">
     <h1 class="h1">{household.name}</h1>
     <div class="actions flex gap-2">
@@ -204,6 +234,9 @@
                 {/if}
               </section>
             </div>
+          {:else}
+            This household currently does not have any bills. Please use the
+            &quot;Add&quot; button above
           {/each}
         </div>
       {/await}

--- a/packages/db/src/tables/households.table.ts
+++ b/packages/db/src/tables/households.table.ts
@@ -1,5 +1,12 @@
 import { sql } from 'drizzle-orm';
-import { date, index, pgTable, text, uuid } from 'drizzle-orm/pg-core';
+import {
+  date,
+  index,
+  pgTable,
+  text,
+  uuid,
+  timestamp,
+} from 'drizzle-orm/pg-core';
 import { users } from './users.table';
 
 export const households = pgTable(
@@ -13,10 +20,12 @@ export const households = pgTable(
     ownerId: uuid('owner_id').references(() => users.id, {
       onDelete: 'set null',
     }),
+    updatedAt: timestamp('updated_at'),
   },
   // Creating an index on the name as we will search on it.
-  ({ name, ownerId }) => ({
+  ({ name, ownerId, updatedAt }) => ({
     name: index('name_index').on(name),
     ownerId: index('owner_id').on(ownerId),
+    updatedAtIdx: index('updated_at_idx').on(updatedAt),
   }),
 );


### PR DESCRIPTION
### TL;DR
Added functionality for users to claim ownership of ownerless households and improved state management.

### What changed?
- Added a new `claimHousehold` server action to handle household ownership transfers
- Implemented a warning alert for households without owners
- Added a "Claim household" button for ownerless households
- Converted component state management to use `$state` and `$derived`
- Added a message for households without any bills
- Added proper TypeScript types for page data

### How to test?
1. Navigate to a household that has no owner
2. Verify that a warning alert is displayed
3. Click the "Claim household" button
4. Confirm that you become the new owner of the household
5. Verify that the warning alert disappears
6. Check that households with no bills display the appropriate message

### Why make this change?
To prevent orphaned households from accumulating in the system and provide a clear mechanism for users to take ownership of abandoned households. This change also improves the user experience by providing better feedback about household ownership status and empty bill states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added ability for users to claim ownership of households
  - Enhanced household dashboard with improved state management and user notifications

- **Improvements**
  - Updated component state handling using Svelte's reactive state management
  - Added warning alert for households without an owner
  - Introduced fallback message for households with no bills

- **Database Changes**
  - Added `updatedAt` timestamp column to households table for better tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->